### PR TITLE
Fix undefined function WP_Filesystem

### DIFF
--- a/src/shorthand_connect.php
+++ b/src/shorthand_connect.php
@@ -24,6 +24,10 @@ require_once('includes/api-v2.php');
 require_once('includes/shorthand_options.php');
 require_once('templates/abstract.php');
 
+if ( !function_exists('WP_Filesystem') ) {
+	require_once(ABSPATH . 'wp-admin/includes/file.php');
+}
+
 /* Create the Shorthand post type */
 function shand_create_post_type()
 {


### PR DESCRIPTION
On my WordPress Multisite installation, I encountered an issue where the WP_Filesystem function was undefined. This error was causing all of my posts and custom post types not to update or save because the function wasn't included. Fixing the problem required checking if the function was defined and if not, then including the appropriate core file.