### PR TITLE
Add in filters and actions for developer points 

### DIFF
--- a/src/includes/api-v2.php
+++ b/src/includes/api-v2.php
@@ -83,9 +83,13 @@ function sh_get_story_path($post_id, $story_id) {
 	}
 	$destination = wp_upload_dir();
 	$destination_path = $destination['path'].'/shorthand/'.$post_id.'/'.$story_id;
+	
 	if(!file_exists($destination_path)) {
 		$destination_path = null;
 	}
+	
+	$destination_path = apply_filters('sh_get_story_path', $destination_path, $destination);
+	
 	return $destination_path;
 }
 

--- a/src/includes/api-v2.php
+++ b/src/includes/api-v2.php
@@ -101,8 +101,12 @@ function sh_get_story_url($post_id, $story_id) {
 		$creds = request_filesystem_credentials( site_url() );
 		wp_filesystem( $creds );
 	}
+	
 	$destination = wp_upload_dir();
 	$destination_url = $destination['url'].'/shorthand/'.$post_id.'/'.$story_id;
+	
+	$destination_url = apply_filters('sh_get_story_url', $destination_url);
+	
 	return $destination_url;
 }
 

--- a/src/includes/api-v2.php
+++ b/src/includes/api-v2.php
@@ -196,5 +196,8 @@ function sh_copy_story($post_id, $story_id) {
 			}
 		}
 	}
+	
+	do_action('sh_copy_story', $post_id, $story_id, $story);
+	
 	return $story;
 }

--- a/src/shorthand_connect.php
+++ b/src/shorthand_connect.php
@@ -480,6 +480,8 @@ function shand_fix_content_paths($assets_path, $content)
 	$content = str_replace('./static/', $assets_path . '/static/', $content);
 	$content = preg_replace('/.(\/theme-\w+.min.css)/', $assets_path . '$1', $content);
 	
+	$content = apply_filters('shand_fix_content_paths', $content);
+	
 	return $content;
 }
 

--- a/src/shorthand_connect.php
+++ b/src/shorthand_connect.php
@@ -315,6 +315,9 @@ function shand_save_shorthand_story($post_id, $post, $update)
 			$body = shand_fix_content_paths($assets_path, defined('WPCOM_IS_VIP_ENV')? file_get_contents($article_file) : $wp_filesystem->get_contents($article_file));
 			$head = shand_fix_content_paths($assets_path, defined('WPCOM_IS_VIP_ENV')? file_get_contents($head_file) 	: $wp_filesystem->get_contents($head_file));
 
+			$body = apply_filters('sh_pre_process_body', $body, $assets_path, $article_file);
+			$head = apply_filters('sh_pre_process_head', $head, $assets_path, $head_file);
+			
 			if(isset($post_processing_queries->body)){
 				$body = shand_post_processing($body,$post_processing_queries->body);
 			}
@@ -322,6 +325,9 @@ function shand_save_shorthand_story($post_id, $post, $update)
 			if(isset($post_processing_queries->head)){
 				$head = shand_post_processing($head, $post_processing_queries->head);
 			}
+			
+			$body = apply_filters('sh_post_process_body', $body, $assets_path, $article_file);
+			$head = apply_filters('sh_post_process_head', $head, $assets_path, $head_file);
 
 			update_post_meta($post_id, 'story_body', wp_slash($body));
 			update_post_meta($post_id, 'story_head', wp_slash($head));


### PR DESCRIPTION
For some context, there is an issue here: https://github.com/Shorthand/shorthand_connect_wordpress/issues/15

This PR is quite non-destructive and has been tested in a real WordPress Multisite. As the linked issue details, these filters and actions were required to hook into various points of the Shorthand Connect plugin to modify paths and call an action when the Shorthand story is updated. The reason for implementing these was to implement a save to S3 bucket scenario for uploads as we are using this plugin on AWS cloud-hosted infrastructure with no fixed storage.

**Here are some examples of how I am using these:**

### When a story is updated

The `copy_local_folder_to_s3` method scans the directory provided in the path, programmatically builds a structure of the downloaded Shorthand assets and then uploads them to an S3 bucket.

```
add_action('sh_copy_story', function($post_id, $story_id, $story) {
    copy_local_folder_to_s3($story['path']);
}, 10, 3);
```

### Modifications to the logic for determining paths

Both of the following are the same. We hook into the logic that loads the `article.html` and `head.html` files. We make our own `file_get_contents` call to load these using the new S3 path. These are then returned to the plugin and saved into postmeta.

```
add_filter('sh_pre_process_body', function($body, $assets_path, $article_file) {
    $load_file = file_get_contents($assets_path . '/article.html');

    return shand_fix_content_paths($assets_path, $load_file);
}, 10, 3);

add_filter('sh_pre_process_head', function($head, $assets_path, $head_file) {
    $load_file = file_get_contents($assets_path . '/head.html');

    return shand_fix_content_paths($assets_path, $load_file);
}, 10, 3);
```