### PR TITLE
Token handling bug fixes

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -66,6 +66,14 @@ https://wordpress.org/plugins/about/svn/
 - [Examples](https://listjs.com/)
 
 ## Changelog
+### 1.3.34
+
+- Fixed issue with API token validation
+- General bug fixes and stability improvements
+
+### 1.3.33
+
+- Updated latest version to WordPress 6.7.2
 
 ### 1.3.32
 

--- a/src/js/connect-stories-fetch.js
+++ b/src/js/connect-stories-fetch.js
@@ -52,7 +52,7 @@ const fetchMoreStories = async () => {
             console.error(error.message);
             const emptyMsg = document.createElement("div");
             emptyMsg.className = "errorMsg";
-            emptyMsg.innerHTML = 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="%s">Shorthand settings</a>.';
+            emptyMsg.innerHTML = 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="options-general.php?page=shorthand-options&navigation=token">Shorthand settings</a>.';
             document.getElementById("stories-list").append(emptyMsg); //phpcs:ignore WordPressVIPMinimum.JS.HTMLExecutingFunctions.append
         }
     }

--- a/src/shorthand-connect.php
+++ b/src/shorthand-connect.php
@@ -10,7 +10,7 @@ Plugin Name: Shorthand Connect
 Plugin URI: http://shorthand.com/
 Description: Import your Shorthand stories into your WordPress CMS as simply as possible - magic!
 Author: Shorthand
-Version: 1.3.32
+Version: 1.3.34
 Author URI: http://shorthand.com
 */
 
@@ -20,8 +20,8 @@ if ( ! function_exists( 'add_action' ) ) {
 	exit;
 }
 
-define( 'SHORTHAND_VERSION', '1.3.32' );
-define( 'SHORTHAND__MINIMUM_WP_VERSION', '5.8' );
+define( 'SHORTHAND_VERSION', '1.3.34' );
+define( 'SHORTHAND__MINIMUM_WP_VERSION', '6.7.2' );
 define( 'SHORTHAND__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once SHORTHAND__PLUGIN_DIR . 'class-shorthand.php';
@@ -126,7 +126,7 @@ function shorthand_wpt_shorthand_story() {
 
 	if ( ! ( $profile ) ) {
 		$uri = Shorthand_Admin::get_page_url();
-		printf( wp_kses( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="%s">Shorthand settings</a>.' ) ), esc_url( $uri ) );
+		printf( wp_kses( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="options-general.php?page=shorthand-options&navigation=token">Shorthand settings</a>.' ) ), esc_url( $uri ) );
 	} else {
 		?>
 	<div id="stories-list">
@@ -182,7 +182,7 @@ function shorthand_wpt_shorthand_story() {
 			)
 		);
 		wp_localize_script('fetch-stories', 'wp_server', array(
-			'url' => ( get_option('permalink_structure') ) ? "/wp-json/shorthand_connect/v1/stories/" : "/?rest_route=/shorthand_connect/v1/stories/",
+			'url' => rest_url('shorthand_connect/v1/stories/'),
 			'nonce' => wp_create_nonce('wp_rest'),
 			'selected_story' => $selected_story
 		));
@@ -304,7 +304,7 @@ function shorthand_save_shorthand_story( $post_id, $post ) {
 	$profile = shorthand_api_get_profile();
 	if ( ( get_post_type( $post ) === 'shorthand_story' ) && ! ( $profile ) ) {
 		$uri = Shorthand_Admin::get_page_url();
-		wp_die( message: sprintf( wp_kses_post ( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="%s">Shorthand settings</a>.', 'shorthand-connect' ) ), esc_url( $uri ) ), title: wp_kses_post( __( 'Shorthand is not connected' ) ) );
+		wp_die( message: sprintf( wp_kses_post ( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="options-general.php?page=shorthand-options&navigation=token">Shorthand settings</a>.', 'shorthand-connect' ) ), esc_url( $uri ) ), title: wp_kses_post( __( 'Shorthand is not connected' ) ) );
 	}
 
 	WP_Filesystem();

--- a/src/shorthand-connect.php
+++ b/src/shorthand-connect.php
@@ -304,7 +304,7 @@ function shorthand_save_shorthand_story( $post_id, $post ) {
 	$profile = shorthand_api_get_profile();
 	if ( ( get_post_type( $post ) === 'shorthand_story' ) && ! ( $profile ) ) {
 		$uri = Shorthand_Admin::get_page_url();
-		wp_die( message: sprintf( wp_kses_post ( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="options-general.php?page=shorthand-options&navigation=token">Shorthand settings</a>.', 'shorthand-connect' ) ), esc_url( $uri ) ), title: wp_kses_post( __( 'Shorthand is not connected' ) ) );
+		wp_die( sprintf( wp_kses_post ( __( 'Could not connect to Shorthand, please check your API token in <a alt="(opens Shorthand Connect plugin settings)" href="options-general.php?page=shorthand-options&navigation=token">Shorthand settings</a>.', 'shorthand-connect' ) ), esc_url( $uri ) ), wp_kses_post( __( 'Shorthand is not connected' ) ) );
 	}
 
 	WP_Filesystem();


### PR DESCRIPTION
https://shorthandhq.slack.com/archives/C025WGSDBMY/p1742808758939849

If a WordPress install is in a folder such as '/test' then the URL would be: https://test.com/test however, our code was sending /wp-json/ to test.com so it would be trying to grab the story URLs from https://test.com/wp-json rather than https://test.com/test/wp-json.

@benhoad I've changed some of the code since you worked on most of this could you check if you spot any issues here as I changed some of the URLs that weren't working too.

Thanks!